### PR TITLE
Split project file in seperate project files

### DIFF
--- a/Quoniam.pro
+++ b/Quoniam.pro
@@ -24,6 +24,7 @@ else {
 
 include(assimp_dependency.pri)
 include(opencv_dependency.pri)
+include(qt_installation.pri)
 
 win32 {
     RC_FILE = Quoniam.rc
@@ -41,30 +42,9 @@ win32 {
     equals(COMPILATION,debug){
         LIBS += -L$$PWD/dependencies/vld/lib/ -lvld
 
-        QT_INSTALL_BINS_WIN = $$[QT_INSTALL_BINS]
-        QT_INSTALL_BINS_WIN = $$replace(QT_INSTALL_BINS_WIN,"/","\\")
-        QT_INSTALL_PLUGINS_WIN = $$[QT_INSTALL_PLUGINS]
-        QT_INSTALL_PLUGINS_WIN = $$replace(QT_INSTALL_PLUGINS_WIN,"/","\\")
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Cored.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Guid.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5OpenGLd.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Widgetsd.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(xcopy "$$QT_INSTALL_PLUGINS_WIN\\platforms\\qwindowsd.dll" "$$OUT_PWD_WIN\\bin\\platforms\\" /Y $$escape_expand(\\n))
-
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\vld_x64.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\dbghelp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\Microsoft.DTfW.DHL.manifest" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-    }
-    else {
-        QT_INSTALL_BINS_WIN = $$[QT_INSTALL_BINS]
-        QT_INSTALL_BINS_WIN = $$replace(QT_INSTALL_BINS_WIN,"/","\\")
-        QT_INSTALL_PLUGINS_WIN = $$[QT_INSTALL_PLUGINS]
-        QT_INSTALL_PLUGINS_WIN = $$replace(QT_INSTALL_PLUGINS_WIN,"/","\\")
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Core.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Gui.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5OpenGL.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Widgets.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(xcopy "$$QT_INSTALL_PLUGINS_WIN\\platforms\\qwindows.dll" "$$OUT_PWD_WIN\\bin\\platforms\\" /Y $$escape_expand(\\n))
     }
 }
 

--- a/Quoniam.pro
+++ b/Quoniam.pro
@@ -23,6 +23,7 @@ else {
 }
 
 include(assimp_dependency.pri)
+include(opencv_dependency.pri)
 
 win32 {
     RC_FILE = Quoniam.rc
@@ -39,15 +40,6 @@ win32 {
     QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\glew\\bin\\glew32.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
     equals(COMPILATION,debug){
         LIBS += -L$$PWD/dependencies/vld/lib/ -lvld
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_core331d
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgproc331d
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgcodecs331d
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_highgui331d
-
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_core331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgproc331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgcodecs331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_highgui331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
 
         QT_INSTALL_BINS_WIN = $$[QT_INSTALL_BINS]
         QT_INSTALL_BINS_WIN = $$replace(QT_INSTALL_BINS_WIN,"/","\\")
@@ -64,16 +56,6 @@ win32 {
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\Microsoft.DTfW.DHL.manifest" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
     }
     else {
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_core331
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgproc331
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgcodecs331
-        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_highgui331
-
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_core331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgproc331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgcodecs331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_highgui331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-
         QT_INSTALL_BINS_WIN = $$[QT_INSTALL_BINS]
         QT_INSTALL_BINS_WIN = $$replace(QT_INSTALL_BINS_WIN,"/","\\")
         QT_INSTALL_PLUGINS_WIN = $$[QT_INSTALL_PLUGINS]
@@ -91,7 +73,6 @@ INCLUDEPATH +=\
     $$PWD/dependencies/glew/include \
     $$PWD/dependencies/glm \
     $$PWD/dependencies/miniball \
-    $$PWD/dependencies/opencv/include \
     $$PWD/dependencies/vld/include \
     $$PWD/src \
     $$PWD/src/core \

--- a/Quoniam.pro
+++ b/Quoniam.pro
@@ -19,30 +19,24 @@ else {
 include(assimp_dependency.pri)
 include(opencv_dependency.pri)
 include(qt_installation.pri)
+include(glm_dependency.pri)
+include(miniball_dependency.pri)
+include(glew_dependency.pri)
 
 win32 {
     RC_FILE = Quoniam.rc
 
     DESTDIR = $$OUT_PWD/bin/
 
-    LIBS += -L$$PWD/dependencies/glew/lib/ -lglew32
     LIBS += opengl32.lib
     LIBS += glu32.lib
 
-    PWD_WIN = $$replace(PWD,"/","\\")
-    OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
-
-    QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\glew\\bin\\glew32.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
     equals(COMPILATION,debug){
         include(vld_dependency.pri)
     }
 }
 
 INCLUDEPATH +=\
-    $$PWD/dependencies/ \
-    $$PWD/dependencies/glew/include \
-    $$PWD/dependencies/glm \
-    $$PWD/dependencies/miniball \
     $$PWD/src \
     $$PWD/src/core \
     $$PWD/src/viewpoint-measures

--- a/Quoniam.pro
+++ b/Quoniam.pro
@@ -22,12 +22,13 @@ else {
     COMPILATION = release
 }
 
+include(assimp_dependency.pri)
+
 win32 {
     RC_FILE = Quoniam.rc
 
     DESTDIR = $$OUT_PWD/bin/
 
-    LIBS += -L$$PWD/dependencies/assimp/lib/$$COMPILATION/ -lassimp
     LIBS += -L$$PWD/dependencies/glew/lib/ -lglew32
     LIBS += opengl32.lib
     LIBS += glu32.lib
@@ -58,7 +59,6 @@ win32 {
         QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Widgetsd.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(xcopy "$$QT_INSTALL_PLUGINS_WIN\\platforms\\qwindowsd.dll" "$$OUT_PWD_WIN\\bin\\platforms\\" /Y $$escape_expand(\\n))
 
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\assimp\\bin\\release\\assimp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\vld_x64.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\dbghelp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\Microsoft.DTfW.DHL.manifest" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
@@ -83,14 +83,11 @@ win32 {
         QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5OpenGL.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Widgets.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
         QMAKE_POST_LINK += $$quote(xcopy "$$QT_INSTALL_PLUGINS_WIN\\platforms\\qwindows.dll" "$$OUT_PWD_WIN\\bin\\platforms\\" /Y $$escape_expand(\\n))
-
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\assimp\\bin\\$$COMPILATION\\assimp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
     }
 }
 
 INCLUDEPATH +=\
     $$PWD/dependencies/ \
-    $$PWD/dependencies/assimp/include \
     $$PWD/dependencies/glew/include \
     $$PWD/dependencies/glm \
     $$PWD/dependencies/miniball \

--- a/Quoniam.pro
+++ b/Quoniam.pro
@@ -1,9 +1,3 @@
-#-------------------------------------------------
-#
-# Project created by QtCreator 2011-02-09T17:08:35
-#
-#-------------------------------------------------
-
 QT += opengl #core and gui are already included
 
 TARGET = Quoniam
@@ -37,14 +31,10 @@ win32 {
 
     PWD_WIN = $$replace(PWD,"/","\\")
     OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
-    # Copy supporting library DLLs
+
     QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\glew\\bin\\glew32.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
     equals(COMPILATION,debug){
-        LIBS += -L$$PWD/dependencies/vld/lib/ -lvld
-
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\vld_x64.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\dbghelp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
-        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\Microsoft.DTfW.DHL.manifest" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        include(vld_dependency.pri)
     }
 }
 
@@ -53,7 +43,6 @@ INCLUDEPATH +=\
     $$PWD/dependencies/glew/include \
     $$PWD/dependencies/glm \
     $$PWD/dependencies/miniball \
-    $$PWD/dependencies/vld/include \
     $$PWD/src \
     $$PWD/src/core \
     $$PWD/src/viewpoint-measures

--- a/assimp_dependency.pri
+++ b/assimp_dependency.pri
@@ -1,0 +1,24 @@
+
+CONFIG(debug, debug|release){
+    COMPILATION = debug
+}
+else {
+    COMPILATION = release
+}
+
+win32 {
+    LIBS += -L$$PWD/dependencies/assimp/lib/$$COMPILATION/ -lassimp
+
+    PWD_WIN = $$replace(PWD,"/","\\")
+    OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
+
+    equals(COMPILATION,debug){
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\assimp\\bin\\release\\assimp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+    }
+    else {
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\assimp\\bin\\$$COMPILATION\\assimp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+    }
+}
+
+INCLUDEPATH +=\
+    $$PWD/dependencies/assimp/include

--- a/glew_dependency.pri
+++ b/glew_dependency.pri
@@ -1,0 +1,10 @@
+win32 {
+    LIBS += -L$$PWD/dependencies/glew/lib/ -lglew32
+
+    PWD_WIN = $$replace(PWD,"/","\\")
+    OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
+    QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\glew\\bin\\glew32.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+}
+
+INCLUDEPATH +=\
+    $$PWD/dependencies/glew/include

--- a/glm_dependency.pri
+++ b/glm_dependency.pri
@@ -1,0 +1,2 @@
+INCLUDEPATH +=\
+    $$PWD/dependencies/glm

--- a/miniball_dependency.pri
+++ b/miniball_dependency.pri
@@ -1,0 +1,2 @@
+INCLUDEPATH +=\
+    $$PWD/dependencies/miniball

--- a/opencv_dependency.pri
+++ b/opencv_dependency.pri
@@ -1,0 +1,36 @@
+CONFIG(debug, debug|release){
+    COMPILATION = debug
+}
+else {
+    COMPILATION = release
+}
+
+win32 {
+    PWD_WIN = $$replace(PWD,"/","\\")
+    OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
+    equals(COMPILATION,debug){
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_core331d
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgproc331d
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgcodecs331d
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_highgui331d
+
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_core331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgproc331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgcodecs331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_highgui331d.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+    }
+    else {
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_core331
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgproc331
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_imgcodecs331
+        LIBS += -L$$PWD/dependencies/opencv/lib/$$COMPILATION/ -lopencv_highgui331
+
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_core331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgproc331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_imgcodecs331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\opencv\\bin\\$$COMPILATION\\opencv_highgui331.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+    }
+}
+
+INCLUDEPATH +=\
+    $$PWD/dependencies/opencv/include

--- a/qt_installation.pri
+++ b/qt_installation.pri
@@ -1,0 +1,34 @@
+CONFIG(debug, debug|release){
+    COMPILATION = debug
+}
+else {
+    COMPILATION = release
+}
+
+win32 {
+    PWD_WIN = $$replace(PWD,"/","\\")
+    OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
+
+    equals(COMPILATION,debug){
+        QT_INSTALL_BINS_WIN = $$[QT_INSTALL_BINS]
+        QT_INSTALL_BINS_WIN = $$replace(QT_INSTALL_BINS_WIN,"/","\\")
+        QT_INSTALL_PLUGINS_WIN = $$[QT_INSTALL_PLUGINS]
+        QT_INSTALL_PLUGINS_WIN = $$replace(QT_INSTALL_PLUGINS_WIN,"/","\\")
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Cored.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Guid.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5OpenGLd.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Widgetsd.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(xcopy "$$QT_INSTALL_PLUGINS_WIN\\platforms\\qwindowsd.dll" "$$OUT_PWD_WIN\\bin\\platforms\\" /Y $$escape_expand(\\n))
+    }
+    else {
+        QT_INSTALL_BINS_WIN = $$[QT_INSTALL_BINS]
+        QT_INSTALL_BINS_WIN = $$replace(QT_INSTALL_BINS_WIN,"/","\\")
+        QT_INSTALL_PLUGINS_WIN = $$[QT_INSTALL_PLUGINS]
+        QT_INSTALL_PLUGINS_WIN = $$replace(QT_INSTALL_PLUGINS_WIN,"/","\\")
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Core.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Gui.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5OpenGL.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(copy "$$QT_INSTALL_BINS_WIN\\Qt5Widgets.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+        QMAKE_POST_LINK += $$quote(xcopy "$$QT_INSTALL_PLUGINS_WIN\\platforms\\qwindows.dll" "$$OUT_PWD_WIN\\bin\\platforms\\" /Y $$escape_expand(\\n))
+    }
+}

--- a/vld_dependency.pri
+++ b/vld_dependency.pri
@@ -1,0 +1,11 @@
+PWD_WIN = $$replace(PWD,"/","\\")
+OUT_PWD_WIN = $$replace(OUT_PWD,"/","\\")
+
+LIBS += -L$$PWD/dependencies/vld/lib/ -lvld
+
+QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\vld_x64.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\dbghelp.dll" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+QMAKE_POST_LINK += $$quote(copy "$$PWD_WIN\\dependencies\\vld\\bin\\Microsoft.DTfW.DHL.manifest" "$$OUT_PWD_WIN\\bin\\" $$escape_expand(\\n))
+
+INCLUDEPATH +=\
+    $$PWD/dependencies/vld/include


### PR DESCRIPTION
To keep a better structure we split the project files in different ones, one per external library and one for quaniam that includes them.