### PR TITLE
Force to use opengl desktop

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -11,6 +11,7 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    app.setAttribute(Qt::AA_UseDesktopOpenGL);
 
     MainWindow* window = MainWindow::GetInstance();
 


### PR DESCRIPTION
Starting with Qt 5.4 opengl desktop is not the default any more.
However this application is strongly dependant on opengl desktop
and it has not been tested with another opengl mode.
We force desktop to make it work as before.