### PR TITLE
Add bazel installation to appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,9 @@ init:
   - call %VCVARSALLPATH% %VCVARSALL%
   - set PATH=C:\Qt\%QT_VERSION%\bin;C:\Qt\Tools\QtCreator\bin;%PATH%;
 
+install:
+  - choco install bazel
+
 build_script:
   - qmake Quoniam.pro
   - jom


### PR DESCRIPTION
In order to have the full build in appveyor, Bazel 3.0.0+ is needed.
For the moment is added the installation to keep track of the version
available.