### PR TITLE
Revert "Use latest rc version"

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,2 +1,2 @@
-3.1.0rc4
+last_downstream_green
 


### PR DESCRIPTION
This reverts commit b71cd49389e16b451913968f17d7507d219c57f1.

Go back to use the latest downstream green.