### PR TITLE
Fix illumination not working

### DIFF
--- a/src/core/GLCanvas.cpp
+++ b/src/core/GLCanvas.cpp
@@ -374,7 +374,7 @@ void GLCanvas::paintGL()
             glBlendEquation(GL_MAX);
 
             mShaderDualPeel->UseProgram();
-            mShaderDualPeel->SetUniform("world", glm::mat4());
+            mShaderDualPeel->SetUniform("world", glm::mat4(1.0f));
             mShaderDualPeel->SetUniform("cameraPosition", mFreeCamera->GetPosition());
 
             mShaderDualPeel->BindTexture(GL_TEXTURE_RECTANGLE, "DepthBlenderTex", mDualDepthTexId[prevId], 1);


### PR DESCRIPTION
After updating glm the illumination stopped working because matrix are no longer default initialized to the identity matrix.